### PR TITLE
Update dockerfile to copy files inside build context

### DIFF
--- a/build/manager/Dockerfile
+++ b/build/manager/Dockerfile
@@ -3,15 +3,15 @@ FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY ../../go.mod go.mod
-COPY ../../go.sum go.sum
+COPY go.mod go.mod
+COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY ../../cmd cmd/
-COPY ../../pkg pkg/
+COPY cmd cmd/
+COPY pkg pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/manager/main.go

--- a/build/webhook/Dockerfile
+++ b/build/webhook/Dockerfile
@@ -3,15 +3,15 @@ FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY ../../go.mod go.mod
-COPY ../../go.sum go.sum
+COPY go.mod go.mod
+COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY ../../cmd/ cmd/
-COPY ../../pkg/ pkg/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o webhook cmd/webhook/main.go


### PR DESCRIPTION
## Description

According to [docker document](https://docs.docker.com/engine/reference/builder/#copy):
> The <src> path must be inside the context of the build; you cannot COPY ../something /something, because the first step of a docker build is to send the context directory (and subdirectories) to the docker daemon.

The files copied in dockerfile should be inside docker build context.

## Issue Reference

Closes: #2 